### PR TITLE
Import of exoplasim.pyfft

### DIFF
--- a/exoplasim/__init__.py
+++ b/exoplasim/__init__.py
@@ -9,6 +9,7 @@ import numpy as np
 import glob
 import exoplasim.gcmt 
 import exoplasim.pyburn
+import exoplasim.pyfft
 import exoplasim.filesupport
 from exoplasim.filesupport import SUPPORTED
 import exoplasim.randomcontinents


### PR DESCRIPTION
Added import of pyfft to __init__

I was getting an error about pyfft not being found from the pyburn readfile function unless I manually imported pyfft first, so I've added an import to __init__.