### PR TITLE
Libration of SSP and additional spin-orbit resonances

### DIFF
--- a/exoplasim/__init__.py
+++ b/exoplasim/__init__.py
@@ -2038,8 +2038,7 @@ class Model(object):
             substellarlon : float, optional
                The longitude of the substellar point, if synchronous==True. Default 180°
             allowlibrate : bool, optional
-               True/False. If True, allows for libration of the substellar point due to obliquity and,
-               if keplerian==True, eccentricity. True by default.
+               True/False. If True and synchronous==True, allows for libration of the substellar point due to obliquity and eccentricity. True by default.
             soldaysperorb : float, optional
                If synchronous==True, solar days experienced per orbit. 0.0 is typical tidal-locked behavior,
                but other values can be used for other spin-orbit resonances, e.g. 0.5 for 3:2 resonance

--- a/exoplasim/plasim/src/radmod.f90
+++ b/exoplasim/plasim/src/radmod.f90
@@ -1416,7 +1416,7 @@
 	  endif
 	  call mpbcr(syncdays)
 	  lonoffset = mod(syncdays,1.0) * (-360.0)
-	  if (allowlibrate > 0 .AND. ngenkeplerian > 0) lonoffset = lonoffset + (orbnu*180.0/PI - (zcday*360.0 + meananom0))
+	  if (allowlibrate > 0) lonoffset = lonoffset + (orbnu*180.0/PI - (zcday*360.0 + meananom0))
         if (mypid==NROOT) fixedlon = fixedlon + desync*mpstep
         call mpbcr(fixedlon)
         zrtim = TWOPI


### PR DESCRIPTION
Two additions for synchronous planets:

- Allow for libration of substellar point due to both obliquity and eccentricity, controlled by the allowlibrate parameter (True by default).
- Allow for specifying a number of solar days per orbit for synchronous planets (with the soldaysperorb parameter), allowing for spin-orbit resonances other than 1:1; Default is 0.0, which keeps the default tidal-locked behavior.

Neither interfere with the existing desynchronization system and they both use the year fraction, so shouldn't be affected by compounding timekeeping errors.

These changes were tested with 3.2.4 (as I can't seem to get 3.3.0 running) but I've tried to ensure they don't interfere with the new aerosol changes.