### PR TITLE
plasim: broadcast nlowio and nstpw (deadlock and silent output corruption)

### DIFF
--- a/exoplasim/plasim/src/plasim.f90
+++ b/exoplasim/plasim/src/plasim.f90
@@ -215,6 +215,25 @@ plasimversion = "https://github.com/Edilbert/PLASIM/ : 15-Dec-2015"
       call mpbci(nveg    ) ! vegetation switch
       call mpbci(noutput ) ! write data switch
       call mpbci(nafter  ) ! write data interval
+!
+!     nlowio and nstpw are read from plasim_nl on NROOT only, exactly like every
+!     key broadcast around here, but unlike them they were never broadcast at
+!     all. Every non-root task therefore kept the COMPILED DEFAULT nlowio = 1
+!     (plasimmod.f90) while NROOT held whatever the namelist said. That is
+!     invisible while the namelist also says 1, and it DEADLOCKS the model when
+!     it says 0: the `if (nlowio .eq. 0)` blocks in outmod.f90 call writegp and
+!     writesp, and writegp opens with the COLLECTIVE mpgagp. NROOT enters that
+!     gather and no other task does, so the tasks desynchronise and the run sits
+!     in mismatched collectives -- 100% CPU, no system time, no output past the
+!     40-byte header, forever.
+!
+!     nafter is broadcast on the line above and is derived from both of these on
+!     NROOT, so the output CADENCE was always consistent across tasks. Only the
+!     branch that decides WHICH fields to write was not, which is why this hid
+!     for as long as the namelist agreed with the default.
+!
+      call mpbci(nlowio  ) ! low-I/O accumulation mode (0/1)
+      call mpbci(nstpw   ) ! timesteps between writes
       call mpbci(nwpd    ) ! number of writes per day
       call mpbci(nsnapshot) ! Switch for writing snapshots
       call mpbci(nstps   ) ! number of steps per snapshot


### PR DESCRIPTION
`nlowio` and `nstpw` are read from `plasim_nl` inside `if (mypid == NROOT)` in `prolog`, like every neighbouring key, but unlike them they are never broadcast. `plasimmod.f90` defaults `nlowio` to 1, so with `NLOWIO = 0` in the namelist rank 0 holds 0 and every other rank holds 1.

On any run with more than one MPI task that has two consequences.

**It can deadlock.** `outmod.f90`'s `if (nlowio .eq. 0)` blocks reach `writegp`/`writesp`, and `writegp` opens with the collective `mpgagp`. Where the branch is not symmetric, NROOT enters a collective no other rank enters. OpenMPI busy-waits, so it presents as a slow run rather than a hung one: 100% CPU, no output past the 40-byte header. gdb shows ranks split between `MPI_Allreduce` under `fixer` and `MPI_Reduce` under `gridpointd`.

**Worse, it can silently corrupt output.** Where the branch *is* symmetric -- and in `outgp` it is, an if/else whose arms write the instantaneous and accumulated versions of the same fields -- collective counts match, nothing hangs, and NROOT feeds its *instantaneous* slice into the same `mpgagp` gather that every other rank feeds an *accumulated* slice into.

Measured with two binaries from one source differing only in this fix, 320 steps at `NLOWIO = 0` from the same restart, 16 ranks, T42: **474 of 8902 data records differ, every header identical.** For surface temperature the only latitude rows that agree are 0-3 -- `NLAT/NPRO = 64/16 = 4`, exactly rank 0's slice, since `mpgagp` places rank r at offset `r*NHOR`. So **60 of 64 rows, 93.75% of the grid**, carried interval means where instantaneous samples were intended, which is the opposite of what `NLOWIO = 0` asks for. Worst: surface temperature by 14.93 K, cloud cover by 0.99, albedo by 0.57. Fields written outside the if/else are byte-identical, which is the control.

The fix broadcasts both keys beside the `mpbci(nafter)` already there. `nafter` is derived from them on NROOT and *is* broadcast, which is why output cadence was always consistent and only the branch was not -- and why this stayed invisible while the namelist agreed with the compiled default.

At `NLOWIO = 1` it is a no-op by construction. Compiles cleanly.