### PR TITLE
outmod: code 54 writes the instantaneous right ascension, not the mean

### DIFF
--- a/exoplasim/plasim/src/outmod.f90
+++ b/exoplasim/plasim/src/outmod.f90
@@ -271,7 +271,7 @@
         
         !Solar right ascension
         arasc = arasc/real(max(1,naccuout))
-        call writescalar(40,rasc*180./PI,54)
+        call writescalar(40,arasc*180./PI,54)
       endif
       
       return


### PR DESCRIPTION
In the `nlowio > 0` branch of `outsc`, five orbital scalars go out as codes 50-54 and four follow the same two lines -- divide the accumulator by `naccuout`, then write the accumulator:

```fortran
aorbnu = aorbnu/real(max(1,naccuout))
call writescalar(40,aorbnu*180./PI,50)
...
ardist = ardist/real(max(1,naccuout))
call writescalar(40,ardist,53)
```

The fifth divides `arasc` and then writes `rasc`. The averaged value is computed and discarded, and the instantaneous right ascension at the output step goes out under code 54 instead.

`arasc` is zeroed in `outreset` and summed in `outaccu` exactly like its four siblings, so the accumulator is correct and only the write is wrong. It is mislabelled rather than noisy: `rasc` advances monotonically through the orbit, so the sampled value leads the interval mean by about half an output interval, and the two agree only in the limit of one accumulation step.

The three other `writescalar(...,54)` sites -- `outsc`'s `nlowio == 0` branch, `snapshotsc`, `hcadencesc` -- are instantaneous streams by definition and correctly write `rasc`. Untouched. One line; compiles cleanly.