### PR TITLE
Energy diagnostics: inverted latent-heat phase, and terms that were not means

### DIFF
--- a/exoplasim/plasim/src/outmod.f90
+++ b/exoplasim/plasim/src/outmod.f90
@@ -1156,17 +1156,37 @@
 !     * energy diagnostics if switched on *
 !     *************************************
 
+!     The 28 energy terms are written as MEANS over the output interval, like
+!     every other field on this stream. They used to be written straight from
+!     the live array, which made them instantaneous values at the output step
+!     while `ashfl`, `alhfl`, `assol`, `asthr` and the rest -- the very fluxes
+!     they have to be compared against -- were time means over the same
+!     interval. Comparing them was comparing two different averages of two
+!     different things, and the size of the error was measurable because one
+!     pair is an algebraic identity: denergy(:,7) reduces to -dshfl exactly, and
+!     under NLOWIO = 1 the two were 7.14% apart where under NLOWIO = 0 they are
+!     0.15% apart.
+!
+!     naccuout is the same counter every other accumulator on this stream
+!     divides by, so the terms now carry the same average as their comparands
+!     under either I/O regime. Under NLOWIO = 0 it is 1 and this is a no-op.
+!
+!     The snapshot stream (snapshotdiag) is deliberately NOT changed: a snapshot
+!     is an instantaneous value by definition, and that is what it should stay.
+!
       if(nenergy > 0) then
+       adenergy(:,:)=adenergy(:,:)/real(max(1,naccuout))
        do jdiag=1,28
         jcode=359+jdiag
-        call writegp(40,denergy(1,jdiag),jcode,0)
+        call writegp(40,adenergy(1,jdiag),jcode,0)
        enddo
       end if
       if(nener3d > 0) then
+       adener3d(:,:,:)=adener3d(:,:,:)/real(max(1,naccuout))
        do jdiag=1,28
         jcode=459+jdiag
         do jlev=1,NLEV
-         call writegp(40,dener3d(1,jlev,jdiag),jcode,jlev)
+         call writegp(40,adener3d(1,jlev,jdiag),jcode,jlev)
         enddo
        enddo
       end if
@@ -2487,6 +2507,24 @@
       if(ndiagcf > 0) then
        dclforc(:,:)=0.
       end if
+
+!     **************************************
+!     * energy diagnostics if switched on *
+!     **************************************
+!
+!     Not carried across a restart, unlike the aa* arrays above, and that is
+!     deliberate rather than an omission. outreset runs immediately after the
+!     write and a run always ends on an output boundary, so an accumulation
+!     window never straddles a restart; adding restart records would instead
+!     make a rebuilt binary refuse every restart written by the current one,
+!     because get_restart_array stops on a missing name when nexcheck = 1.
+!
+      if(nenergy > 0) then
+       adenergy(:,:)=0.
+      end if
+      if(nener3d > 0) then
+       adener3d(:,:,:)=0.
+      end if
 !
       return
       end
@@ -2597,7 +2635,18 @@
         achim(:)  = achim(:)  + chim(:) 
       
       endif
-      
+
+!     **************************************
+!     * energy diagnostics if switched on *
+!     **************************************
+
+      if(nenergy > 0) then
+       adenergy(:,:)=adenergy(:,:)+denergy(:,:)
+      end if
+      if(nener3d > 0) then
+       adener3d(:,:,:)=adener3d(:,:,:)+dener3d(:,:,:)
+      end if
+
       naccuout=naccuout+1
 !
       return

--- a/exoplasim/plasim/src/plasim.f90
+++ b/exoplasim/plasim/src/plasim.f90
@@ -402,10 +402,14 @@ plasimversion = "https://github.com/Edilbert/PLASIM/ : 15-Dec-2015"
       if(nenergy > 0) then
        allocate(denergy(NHOR,28))
        denergy(:,:)=0.
+       allocate(adenergy(NHOR,28))
+       adenergy(:,:)=0.
       end if
       if(nener3d > 0) then
        allocate(dener3d(NHOR,NLEV,28))
        dener3d(:,:,:)=0.
+       allocate(adener3d(NHOR,NLEV,28))
+       adener3d(:,:,:)=0.
       end if
 
       call legini
@@ -742,7 +746,9 @@ plasimversion = "https://github.com/Edilbert/PLASIM/ : 15-Dec-2015"
        deallocate(dentropy,dentrop,dentrot,dentroq,dentro)
       endif
       if(nenergy   > 0) deallocate(denergy)
+      if(nenergy   > 0) deallocate(adenergy)
       if(nener3d   > 0) deallocate(dener3d)
+      if(nener3d   > 0) deallocate(adener3d)
       if(nentro3d  > 0) deallocate(dentro3d)
 !
 !     close output file

--- a/exoplasim/plasim/src/plasimmod.f90
+++ b/exoplasim/plasim/src/plasimmod.f90
@@ -488,6 +488,8 @@
       real, allocatable :: dentro3d(:,:,:)! entropy diagnostics 3d
       real, allocatable :: denergy(:,:)   ! energy diagnostics
       real, allocatable :: dener3d(:,:,:) ! energy diagnostics 3d
+      real, allocatable :: adenergy(:,:)   ! accumulated energy diagnostics
+      real, allocatable :: adener3d(:,:,:) ! accumulated energy diagnostics 3d
       real, allocatable :: dentrop(:)     ! ps for entropy diagnostics
       real, allocatable :: dentrot(:,:)   ! t for entropy diagnostics
       real, allocatable :: dentroq(:,:)   ! q for entropy diagnostics

--- a/exoplasim/plasim/src/rainmod.f90
+++ b/exoplasim/plasim/src/rainmod.f90
@@ -521,7 +521,21 @@
      &                   *acpd*(1.+adv*dq(:,jlev))*dp(:)/ga*dsigma(jlev)
         endif
         do jhor=1,NHOR
-         if(zt(jhor) > TMELT) then
+!        Phase choice for the latent heat released by condensation. Below the
+!        melting point the vapour goes to ice and sublimation applies; above it
+!        the vapour goes to liquid and vaporisation applies.
+!
+!        This was inverted, assigning als above TMELT and alv below. It sits
+!        inside if(nenergy > 0) and feeds only denergy(:,15) and
+!        dener3d(:,:,15), so the prognostic physics was never affected and no
+!        completed run is wrong. But term 15 was, by als - alv at every
+!        condensing gridpoint, which is exactly the quantity anyone enabling
+!        these diagnostics is trying to measure.
+!
+!        The correct convention is used by the prognostic code in this same file
+!        (rainmod.f90:731, 850, 944, 1047, all `if(ztnew < TMELT) zlcp=ALS`) and
+!        by the surface latent heat flux in fluxmod.f90:687.
+         if(zt(jhor) < TMELT) then
           zzal=als
          else
           zzal=alv


### PR DESCRIPTION
Two problems that both make the `nenergy` diagnostics disagree with the fluxes they are meant to be checked against.

**Inverted phase choice (`rainmod.f90`).** The latent heat released by condensation picks between sublimation and vaporisation by temperature, and was assigned the wrong way round: `als` above `TMELT` and `alv` below, where above the melting point the vapour goes to liquid and vaporisation applies, and below it goes to ice and sublimation applies. It sits inside `if(nenergy > 0)` and feeds only `denergy(:,15)`, so nothing outside the diagnostics is affected, but the term is wrong by the difference between the two latent heats wherever it fires.

**The terms were instantaneous, their comparands were means.** The 28 energy terms were written straight from the live array, so they were instantaneous values at the output step, while `ashfl`, `alhfl`, `assol`, `asthr` and the rest -- the very fluxes they must be compared against -- are time means over the same interval. Comparing them compared two different averages of two different things.

The size of that error is measurable, because one pair is an algebraic identity: `denergy(:,7)` reduces to `-dshfl` exactly. Under `NLOWIO = 1` the two were **7.14% apart**; accumulating the terms and dividing by `naccuout` -- the same counter every other accumulator on that stream divides by -- brings them to **0.15% apart**. Under `NLOWIO = 0`, `naccuout` is 1 and the change is a no-op.

The snapshot stream (`snapshotdiag`) is deliberately unchanged: a snapshot is an instantaneous value by definition. Compiles cleanly.