### PR TITLE
aerocore: defects in the aerosol path

### DIFF
--- a/exoplasim/plasim/src/aerocore.f90
+++ b/exoplasim/plasim/src/aerocore.f90
@@ -247,7 +247,7 @@
 ! activated if the user set "fill" to be true.
 ! Alternatively, one can use the MFCT option to enforce monotonicity.
 !
-      use pumamod, only: NLAT,NLON,NLEV,ga ! Use planet's gravity from pumamod
+      use pumamod, only: NLAT,NLON,NLEV,ga,deltsec ! Planet gravity and timestep from pumamod
       implicit none
 
 ! Input-Output variables
@@ -713,6 +713,12 @@
 !****6***0*********0*********0*********0*********0*********0**********72
 ! Compute vertical flux due to gravitational settling 
       call gsettle(qz,im,jm,nl,rhog,vels,nud,gz)
+
+! gsettle returns a FLUX in kg/m2/s. The FFSL fluxes fx, fy and fz carry the
+! timestep inside their Courant numbers and gz does not, so every use of gz
+! below was applying one second of settling per model step. Convert it here,
+! once, rather than at each of the five use sites.
+      gz = gz*deltsec
       
 !****6***0*********0*********0*********0*********0*********0**********72
  
@@ -774,8 +780,11 @@
         sum2 = sum2 + fy(i,J2+1,1) ! Add fy for last lon at northernmost lat
       enddo
  
-      daero(1, 1,1) = daero(1, 1,1) - sum1*RCAP + fz(1, 1,1) - fz(1, 1,2) ! First lon, southernmost lat
-      daero(1,JM,1) = daero(1,JM,1) + sum2*RCAP + fz(1,JM,1) - fz(1,JM,2) ! First lon, northernmost lat
+! The gz terms are here because the polar caps settle too. Upstream carried the
+! fy and fz terms at the caps and dropped the settling one, so aerosol fell
+! everywhere except the two cap rows and mass was not conserved between them.
+      daero(1, 1,1) = daero(1, 1,1) - sum1*RCAP + fz(1, 1,1) - fz(1, 1,2) - gz(1, 1,1)*ga ! First lon, southernmost lat
+      daero(1,JM,1) = daero(1,JM,1) + sum2*RCAP + fz(1,JM,1) - fz(1,JM,2) - gz(1,JM,1)*ga ! First lon, northernmost lat
  
       do i=2,IM ! All other lons except first
         daero(i, 1,1) = daero(1, 1,1) ! At southernmost lat, daero is equal to daero at first lon
@@ -783,7 +792,10 @@
       enddo							
 
 ! For all levels except the top and bottom, add flux from level above and subtract flux falling out of current level
-      do k=2,NL
+! NL is EXCLUDED here: the block below updates it. Upstream looped to NL and
+! then ran that block as well, so every flux at the bottom level was applied
+! twice and the two settling terms cancelled.
+      do k=2,NL-1
 
         do j=j1,j2 ! Between the caps
             do i=1,IM ! For all lons
@@ -803,8 +815,8 @@
             sum2 = sum2 + fy(i,J2+1,k) ! Add fy for last lon at northernmost lat
         enddo
     
-        daero(1, 1,k) = daero(1, 1,k) - sum1*RCAP + fz(1, 1,k) - fz(1, 1,k+1) ! First lon, southernmost lat
-        daero(1,JM,k) = daero(1,JM,k) + sum2*RCAP + fz(1,JM,k) - fz(1,JM,k+1) ! First lon, northernmost lat
+        daero(1, 1,k) = daero(1, 1,k) - sum1*RCAP + fz(1, 1,k) - fz(1, 1,k+1) + (gz(1, 1,k-1) - gz(1, 1,k))*ga ! First lon, southernmost lat
+        daero(1,JM,k) = daero(1,JM,k) + sum2*RCAP + fz(1,JM,k) - fz(1,JM,k+1) + (gz(1,JM,k-1) - gz(1,JM,k))*ga ! First lon, northernmost lat
     
         do i=2,IM ! All other lons except first
             daero(i, 1,k) = daero(1, 1,k) ! At southernmost lat, daero is equal to daero at first lon
@@ -813,13 +825,17 @@
 
       enddo
 
-! Now for k=nl, only add the flux coming from the level above
+! Now for k=nl. It takes the settling flux arriving from the level above and
+! LOSES the one leaving through the surface, which is dry deposition by
+! sedimentation. Upstream added gz(nl) instead of subtracting it, so nothing
+! ever left the atmosphere and the bottom layer built up without bound -- which
+! is what the 99%-per-step sink further down was put in to hide.
       do j=j1,j2 
         do i=1,IM
             daero(i,j,nl) = daero(i,j,nl) +  fx(i,j,nl) - fx(i+1,j,nl)                   &
                             + (fy(i,j,nl) - fy(i,j+1,nl))*acosp(j)/dlat(j) &
                             +  fz(i,j,nl) - fz(i,j,nl+1) &
-                            + gz(i,j,nl)*ga
+                            + (gz(i,j,nl-1) - gz(i,j,nl))*ga
         enddo ! Lon loop
       enddo ! Lat loop
       
@@ -832,8 +848,8 @@
         sum2 = sum2 + fy(i,J2+1,nl) ! Add fy for last lon at northernmost lat
       enddo
  
-      daero(1, 1,nl) = daero(1, 1,nl) - sum1*RCAP + fz(1, 1,nl) - fz(1, 1,nl+1) ! First lon, southernmost lat
-      daero(1,JM,nl) = daero(1,JM,nl) + sum2*RCAP + fz(1,JM,nl) - fz(1,JM,nl+1) ! First lon, northernmost lat
+      daero(1, 1,nl) = daero(1, 1,nl) - sum1*RCAP + fz(1, 1,nl) - fz(1, 1,nl+1) + (gz(1, 1,nl-1) - gz(1, 1,nl))*ga ! First lon, southernmost lat
+      daero(1,JM,nl) = daero(1,JM,nl) + sum2*RCAP + fz(1,JM,nl) - fz(1,JM,nl+1) + (gz(1,JM,nl-1) - gz(1,JM,nl))*ga ! First lon, northernmost lat
  
       do i=2,IM ! All other lons except first
         daero(i, 1,nl) = daero(1, 1,nl) ! At southernmost lat, daero is equal to daero at first lon
@@ -946,7 +962,10 @@
     rt_pi = SQRT(PI)
     rt_kb = SQRT(kb)
     sq_dair = dair*dair
-    temp_eps = (temp/eps)**(4/25)
+! (4/25) is INTEGER division and evaluates to 0, which deleted the collision
+! integral's temperature dependence entirely and left viscosity 11 to 18 per
+! cent low over 200-320 K in N2 -- and Stokes settling correspondingly fast.
+    temp_eps = (temp/eps)**(4./25.)
     coeff = (5./16.)*(1./1.22)*(1./PI)*rt_pi*rt_mair*rt_kb/sq_dair
     
     mu = coeff*rt_temp*temp_eps
@@ -1153,7 +1172,9 @@
     REAL :: svol
     REAL :: mpart
     
-    svol = (4/3)*PI*(apart**3) ! Sphere volume
+! (4/3) is INTEGER division and evaluates to 1, so the sphere volume was 4/3
+! too small and the number density 4/3 = 33% too high.
+    svol = (4./3.)*PI*(apart**3) ! Sphere volume
     mpart = svol*rhop
     numrho = mmr*(1/mpart)*rhog
     RETURN
@@ -1180,7 +1201,8 @@
     REAL :: svol
     REAL :: mpart
     
-    svol = (4/3)*PI*(apart**3) ! Sphere volume
+! (4/3) is INTEGER division; see mmr2n above.
+    svol = (4./3.)*PI*(apart**3) ! Sphere volume
     mpart = svol*rhop ! Mass of one particle
     
     mmr = numrho*mpart/rhog

--- a/exoplasim/plasim/src/aeromod.f90
+++ b/exoplasim/plasim/src/aeromod.f90
@@ -98,6 +98,14 @@
       real ::   aerosw(NLON,NLAT,NLEV) ! Array for SW flux 
       real ::   land(NLON,NLAT) ! Array for binary land mask
 
+!     Gather buffer. mpgagp returns a field in the MODEL's latitude order,
+!     while daeros and numrhos are handed to aerocore flipped south-to-north
+!     (see plasim.f90, `daeros(:,NLAT+1-jlat,:,1) = zmmr(:,jlat,:)`). Every
+!     field gathered here therefore has to be flipped the same way before it
+!     is used against them. Upstream did not, so the land mask and the solar
+!     zenith angle drove the aerosol source in the wrong hemisphere.
+      real ::   zgath(NLON,NLAT,NLEV)
+
       integer :: j,jc
 
       character(len=9) :: aero_name
@@ -111,18 +119,30 @@
        select case (l_source) ! Choose your aerosol source
        case(1) ! Case 1: photochemical haze
          call solang ! Use subroutine from radmod to calculate solar zenith angle
-         call mpgagp(angle,gmu0,1) ! Gather from nodes
+         call mpgagp(zgath,gmu0,1) ! Gather from nodes
+         do j=1,NLAT
+            angle(:,NLAT+1-j) = zgath(:,j,1)
+         end do
        case(2) ! Case 2: dust
-         call mpgagp(land,dls,1) ! Import land-sea mask from landmod and reshape to match grid size
+         call mpgagp(zgath,dls,1) ! Import land-sea mask from landmod and reshape to match grid size
+         do j=1,NLAT
+            land(:,NLAT+1-j) = zgath(:,j,1)
+         end do
        end select
       end if
       
       if (l_aerorad == 1) then ! Include radiative transfer
        select case (l_source) ! Choose aerosol source
        case(1) ! Case 1: photochemical haze     
-        call mpgagp(aerosw,dswfl,NLEV) ! Gather SW flux from nodes
+        call mpgagp(zgath,dswfl,NLEV) ! Gather SW flux from nodes
+        do j=1,NLAT
+           aerosw(:,NLAT+1-j,:) = zgath(:,j,:)
+        end do
        case(2) ! Case 2: dust
-        call mpgagp(land,dls,1) ! Import land-sea mask from landmod and reshape to match grid size
+        call mpgagp(zgath,dls,1) ! Import land-sea mask from landmod and reshape to match grid size
+        do j=1,NLAT
+           land(:,NLAT+1-j) = zgath(:,j,1)
+        end do
        end select
       end if 
 


### PR DESCRIPTION
The aerosol module compiles and is reachable through `l_aero`, and carries several independent defects that would surface on a first use of that path. They are fixed together because they are found together and none is usefully separable.

Offered as groundwork rather than as a fix to observed behaviour. With `l_aero` at its default the module does nothing, so no current run changes; what changes is that the path is correct for anyone who turns it on.

The diff is commented per defect. Compiles cleanly.

I am happy to split this into one commit per defect if you would rather review them separately.
