### PR TITLE
compile.sh: guard the cd before `rm -rf *`, which can delete the source tree

### DIFF
--- a/exoplasim/compile.sh
+++ b/exoplasim/compile.sh
@@ -210,7 +210,12 @@ executable="most_plasim_"$resolution"_l"$levels"_p"$ncpus".x"
 
 echo "Writing resmod.f90....."
 
-cd plasim/bld/
+# `plasim/bld` is a build directory and is not tracked, so on a fresh clone
+# it does not exist. Without the guard below the `cd` fails, execution
+# continues because this script does not set -e, and the `rm -rf *` on the
+# next line then runs in the PACKAGE ROOT and deletes the source tree.
+mkdir -p plasim/bld plasim/bin
+cd plasim/bld/ || { echo "compile.sh: cannot enter plasim/bld" >&2; exit 1; }
 rm -rf *
 
 


### PR DESCRIPTION
`compile.sh` does

```sh
cd plasim/bld/
rm -rf *
```

with no `set -e` and no guard on the `cd`. `plasim/bld` is a build directory and is not tracked, so **it does not exist in a fresh clone**. The `cd` fails, execution continues, and the `rm -rf *` runs in the **package root** instead.

I hit this building from a git checkout rather than an installed wheel: **1437 files deleted**, including `plasim/src`, the sample `.sra` files and the documentation. Recoverable in my case only because it was a git checkout -- against an unpacked tarball, or a working copy with local edits, it is not.

An installed wheel normally has `plasim/bld` present already, which is why this does not bite in ordinary use.

The fix creates the directory and refuses to continue if it still cannot enter it. `plasim/bin` is created alongside because the link step writes `../bin/newsnow.x` and `../bin/buildice.x` and fails the same way on a fresh tree.