### PR TITLE
aerosol: give radmod the particle radius the namelist asked for

### DIFF
--- a/exoplasim/plasim/src/aeromod.f90
+++ b/exoplasim/plasim/src/aeromod.f90
@@ -52,7 +52,7 @@
 
       subroutine aero_ini
       use aeromod
-      use radmod, only: l_aerorad, aerofile
+      use radmod, only: l_aerorad, aerofile, rad_apart => apart
       
       namelist/aero_nl/l_source,l_bulk,apart,rhop,fcoeff,l_aerorad,aerofile
 
@@ -66,6 +66,16 @@
          write(nud,'(" * Namelist AERO_NL from <aero_namelist> *")')
          write(nud,'(" *********************************************")')
          write(nud,aero_nl)
+!
+!        radmod declares its own `apart` and this namelist sets aeromod's, so
+!        without the line below the transport uses the radius the run asked for
+!        while the radiation keeps radmod's 50 nm default. Optical depth goes as
+!        the radius squared, so the shortwave aerosol came out (50e-9/apart)**2
+!        of intent. radini broadcasts it, which is why this can sit inside the
+!        NROOT block. The two variables stay separate because radmod cannot use
+!        aeromod: aeromod already uses radmod, and make_plasim compiles it second.
+!
+         rad_apart = apart
       endif
       
       return

--- a/exoplasim/plasim/src/radmod.f90
+++ b/exoplasim/plasim/src/radmod.f90
@@ -609,7 +609,6 @@
      &               ,nsol,nclouds,nswrcl,nrscat,rcl1,rcl2,acl2,clgray,tpofmt   &
      &               ,acllwr,tswr1,tswr2,tswr3,th2oc,dawn,starbbtemp,nstartemp  &
      &               ,nsimplealbedo,nstarfile,starfile,starfilehr,minwavel
-     namelist/aero_nl/l_source,l_bulk,apart,rhop,fcoeff,l_aerorad,aerofile
 !
 !     namelist parameter:
 !
@@ -794,6 +793,13 @@
       call mpbcr(minwavel)
       
       call mpbci(l_aerorad)
+!
+!     aero_ini runs on NROOT only and has copied aero_nl's particle radius
+!     into radmod's own by this point. Without this broadcast every other
+!     rank keeps the 50 nm default. Harmless where aero_ini never ran,
+!     because both copies are then the same default.
+!
+      call mpbcr(apart)
 
 !      
 !     determine stellar parameters      


### PR DESCRIPTION
`apart`, the aerosol particle radius, is declared **twice** -- in `aeromod` and in `radmod`, both defaulting to 50 nm -- and only aeromod's is in a namelist. `aero_ini` reads `aero_nl` into aeromod's copy and use-associates `l_aerorad` and `aerofile` from radmod, but **not** `apart`, so radmod's copy keeps its compiled default however the run is configured.

The two halves of the shortwave optical depth then disagree about the particle. `aerocore` calls `mmr2n(mmr, apart, rhop, ...)` with aeromod's value, so the number density `nrho` is right for the particle the run asked for. `radmod`'s `aeroprof` then computes

```fortran
daerod = nrho * PI * apart**2 * qex1 * zdz
```

with radmod's value. For fixed mass `nrho` goes as 1/r³ and the optical depth as nrho·r², so a consistent calculation goes as 1/r; with the copies disagreeing the model computes `nrho(r_true) * r_radmod²`, and

**τ_computed / τ_intended = (50e-9 / r_true)²**

Both defaults are 50 nm, so nothing happens until a run sets `apart` — but a run that sets it is exactly a run that meant to. At 500 nm the radiation sees **1%** of the intended optical depth; at 1 µm, 0.25%.

### Why it is invisible

`radmod` **also** declares `namelist/aero_nl/` including its own `apart`, and nothing in radmod ever opens or reads that namelist — `aero_ini` is the only reader and it reads aeromod's group. So radmod looks wired up and is not. That declaration is removed here, because leaving it is what makes the defect impossible to see by reading.

### The fix

Two lines of mechanism: `aero_ini` copies its namelist value into radmod's, and `radini` broadcasts it beside the `l_aerorad` broadcast already there. The two variables stay separate because radmod cannot `use` aeromod — aeromod already uses radmod, and `make_plasim` compiles it second.

Compiles at T21/8. No behaviour change for any run that leaves `apart` at its default.