### PR TITLE
aerosol: a deposition velocity and wet scavenging, replacing a timestep-dependent sink

### DIFF
--- a/exoplasim/plasim/src/aerocore.f90
+++ b/exoplasim/plasim/src/aerocore.f90
@@ -247,7 +247,7 @@
 ! activated if the user set "fill" to be true.
 ! Alternatively, one can use the MFCT option to enforce monotonicity.
 !
-      use pumamod, only: NLAT,NLON,NLEV,ga ! Use planet's gravity from pumamod
+      use pumamod, only: NLAT,NLON,NLEV,ga,deltsec ! Planet gravity and timestep from pumamod
       implicit none
 
 ! Input-Output variables
@@ -713,6 +713,12 @@
 !****6***0*********0*********0*********0*********0*********0**********72
 ! Compute vertical flux due to gravitational settling 
       call gsettle(qz,im,jm,nl,rhog,vels,nud,gz)
+
+! gsettle returns a FLUX in kg/m2/s. The FFSL fluxes fx, fy and fz carry the
+! timestep inside their Courant numbers and gz does not, so every use of gz
+! below was applying one second of settling per model step. Convert it here,
+! once, rather than at each of the five use sites.
+      gz = gz*deltsec
       
 !****6***0*********0*********0*********0*********0*********0**********72
  
@@ -774,8 +780,11 @@
         sum2 = sum2 + fy(i,J2+1,1) ! Add fy for last lon at northernmost lat
       enddo
  
-      daero(1, 1,1) = daero(1, 1,1) - sum1*RCAP + fz(1, 1,1) - fz(1, 1,2) ! First lon, southernmost lat
-      daero(1,JM,1) = daero(1,JM,1) + sum2*RCAP + fz(1,JM,1) - fz(1,JM,2) ! First lon, northernmost lat
+! The gz terms are here because the polar caps settle too. Upstream carried the
+! fy and fz terms at the caps and dropped the settling one, so aerosol fell
+! everywhere except the two cap rows and mass was not conserved between them.
+      daero(1, 1,1) = daero(1, 1,1) - sum1*RCAP + fz(1, 1,1) - fz(1, 1,2) - gz(1, 1,1)*ga ! First lon, southernmost lat
+      daero(1,JM,1) = daero(1,JM,1) + sum2*RCAP + fz(1,JM,1) - fz(1,JM,2) - gz(1,JM,1)*ga ! First lon, northernmost lat
  
       do i=2,IM ! All other lons except first
         daero(i, 1,1) = daero(1, 1,1) ! At southernmost lat, daero is equal to daero at first lon
@@ -783,7 +792,10 @@
       enddo							
 
 ! For all levels except the top and bottom, add flux from level above and subtract flux falling out of current level
-      do k=2,NL
+! NL is EXCLUDED here: the block below updates it. Upstream looped to NL and
+! then ran that block as well, so every flux at the bottom level was applied
+! twice and the two settling terms cancelled.
+      do k=2,NL-1
 
         do j=j1,j2 ! Between the caps
             do i=1,IM ! For all lons
@@ -803,8 +815,8 @@
             sum2 = sum2 + fy(i,J2+1,k) ! Add fy for last lon at northernmost lat
         enddo
     
-        daero(1, 1,k) = daero(1, 1,k) - sum1*RCAP + fz(1, 1,k) - fz(1, 1,k+1) ! First lon, southernmost lat
-        daero(1,JM,k) = daero(1,JM,k) + sum2*RCAP + fz(1,JM,k) - fz(1,JM,k+1) ! First lon, northernmost lat
+        daero(1, 1,k) = daero(1, 1,k) - sum1*RCAP + fz(1, 1,k) - fz(1, 1,k+1) + (gz(1, 1,k-1) - gz(1, 1,k))*ga ! First lon, southernmost lat
+        daero(1,JM,k) = daero(1,JM,k) + sum2*RCAP + fz(1,JM,k) - fz(1,JM,k+1) + (gz(1,JM,k-1) - gz(1,JM,k))*ga ! First lon, northernmost lat
     
         do i=2,IM ! All other lons except first
             daero(i, 1,k) = daero(1, 1,k) ! At southernmost lat, daero is equal to daero at first lon
@@ -813,13 +825,17 @@
 
       enddo
 
-! Now for k=nl, only add the flux coming from the level above
+! Now for k=nl. It takes the settling flux arriving from the level above and
+! LOSES the one leaving through the surface, which is dry deposition by
+! sedimentation. Upstream added gz(nl) instead of subtracting it, so nothing
+! ever left the atmosphere and the bottom layer built up without bound -- which
+! is what the 99%-per-step sink further down was put in to hide.
       do j=j1,j2 
         do i=1,IM
             daero(i,j,nl) = daero(i,j,nl) +  fx(i,j,nl) - fx(i+1,j,nl)                   &
                             + (fy(i,j,nl) - fy(i,j+1,nl))*acosp(j)/dlat(j) &
                             +  fz(i,j,nl) - fz(i,j,nl+1) &
-                            + gz(i,j,nl)*ga
+                            + (gz(i,j,nl-1) - gz(i,j,nl))*ga
         enddo ! Lon loop
       enddo ! Lat loop
       
@@ -832,8 +848,8 @@
         sum2 = sum2 + fy(i,J2+1,nl) ! Add fy for last lon at northernmost lat
       enddo
  
-      daero(1, 1,nl) = daero(1, 1,nl) - sum1*RCAP + fz(1, 1,nl) - fz(1, 1,nl+1) ! First lon, southernmost lat
-      daero(1,JM,nl) = daero(1,JM,nl) + sum2*RCAP + fz(1,JM,nl) - fz(1,JM,nl+1) ! First lon, northernmost lat
+      daero(1, 1,nl) = daero(1, 1,nl) - sum1*RCAP + fz(1, 1,nl) - fz(1, 1,nl+1) + (gz(1, 1,nl-1) - gz(1, 1,nl))*ga ! First lon, southernmost lat
+      daero(1,JM,nl) = daero(1,JM,nl) + sum2*RCAP + fz(1,JM,nl) - fz(1,JM,nl+1) + (gz(1,JM,nl-1) - gz(1,JM,nl))*ga ! First lon, northernmost lat
  
       do i=2,IM ! All other lons except first
         daero(i, 1,nl) = daero(1, 1,nl) ! At southernmost lat, daero is equal to daero at first lon
@@ -946,7 +962,10 @@
     rt_pi = SQRT(PI)
     rt_kb = SQRT(kb)
     sq_dair = dair*dair
-    temp_eps = (temp/eps)**(4/25)
+! (4/25) is INTEGER division and evaluates to 0, which deleted the collision
+! integral's temperature dependence entirely and left viscosity 11 to 18 per
+! cent low over 200-320 K in N2 -- and Stokes settling correspondingly fast.
+    temp_eps = (temp/eps)**(4./25.)
     coeff = (5./16.)*(1./1.22)*(1./PI)*rt_pi*rt_mair*rt_kb/sq_dair
     
     mu = coeff*rt_temp*temp_eps
@@ -1153,7 +1172,9 @@
     REAL :: svol
     REAL :: mpart
     
-    svol = (4/3)*PI*(apart**3) ! Sphere volume
+! (4/3) is INTEGER division and evaluates to 1, so the sphere volume was 4/3
+! too small and the number density 4/3 = 33% too high.
+    svol = (4./3.)*PI*(apart**3) ! Sphere volume
     mpart = svol*rhop
     numrho = mmr*(1/mpart)*rhog
     RETURN
@@ -1180,7 +1201,8 @@
     REAL :: svol
     REAL :: mpart
     
-    svol = (4/3)*PI*(apart**3) ! Sphere volume
+! (4/3) is INTEGER division; see mmr2n above.
+    svol = (4./3.)*PI*(apart**3) ! Sphere volume
     mpart = svol*rhop ! Mass of one particle
     
     mmr = numrho*mpart/rhog

--- a/exoplasim/plasim/src/aerocore.f90
+++ b/exoplasim/plasim/src/aerocore.f90
@@ -13,7 +13,7 @@
                         cose,cosp,acosp,dlat,rcap,        &
                         cnst,deform,zcross,               &
                         fill,mfct,debug,nud,angle,land,   &
-                        aerosw,l_aerorad)
+                        aerosw,l_aerorad,prec)
 !****6***0*********0*********0*********0*********0*********0**********72
 !
 ! The subroutine aerocore is a duplicate of the tracer transport
@@ -248,6 +248,7 @@
 ! Alternatively, one can use the MFCT option to enforce monotonicity.
 !
       use pumamod, only: NLAT,NLON,NLEV,ga,deltsec ! Planet gravity and timestep from pumamod
+      use aeromod, only: ldepvel,vdaero,lwetdep,scava,scavb ! Removal switches
       implicit none
 
 ! Input-Output variables
@@ -297,6 +298,9 @@
       real ::   angle(im,jm) ! Array for cosine of solar zenith angle
       real ::   land(im,jm) ! Array for binary land mask
       real ::   aerosw(im,jm,nl) ! Array for net SW flux
+      real,intent(in) :: prec(im,jm) ! Total precipitation rate (m/s), for lwetdep
+      real ::   zdz(im,jm) ! Geometric thickness of the bottom layer (m)
+      real ::   zlam(im,jm) ! Below-cloud scavenging rate (1/s)
 
 ! scalars
 
@@ -881,8 +885,41 @@
         mmr(:,:,:,IC) = daero(:,:,:) / delp2dyn(:,:,:)
       end select
 
-! Finally, put in a sink term at the bottom level to avoid infinite build-up of haze particles	  
-      mmr(:,:,nl,ic) = mmr(:,:,nl,ic)*10e-3
+! Dry deposition at the bottom level, over and above sedimentation.
+!
+! ldepvel = 0 keeps the legacy sink, which removes 99% of the bottom layer
+! every timestep whatever the timestep is. ldepvel = 1 replaces it with a
+! deposition velocity acting over the layer's own geometric depth, which is
+! the only form whose implied removal rate is independent of the step.
+!
+! vdaero is the NON-gravitational part on purpose. Settling out of the bottom
+! layer is already taken by the gz(nl) term in the final update above, so
+! adding a Stokes velocity here would deposit the same mass twice.
+      select case (ldepvel)
+      case(0)
+        mmr(:,:,nl,ic) = mmr(:,:,nl,ic)*10e-3
+      case(1)
+        zdz(:,:) = delp2dyn(:,:,nl)/max(rhog(:,:,nl)*ga,1.E-6)
+        mmr(:,:,nl,ic) = mmr(:,:,nl,ic)                                    &
+                       * exp(-min(vdaero*deltsec/max(zdz(:,:),1.0),50.))
+      end select
+
+! Below-cloud wet scavenging, Sportisse (2007): Lambda = A p**B with p in
+! mm/h, which is the form and the coefficients the run's own configuration
+! already carries for the offline chain. prec arrives in m/s, hence 3.6E6.
+!
+! Applied to the whole column rather than below a diagnosed cloud base. That
+! is the offline chain's own approximation, kept deliberately so the two agree
+! in form; it overstates the scavenging of aerosol sitting above the
+! precipitating layer and is the first thing to refine if the wet sink turns
+! out to dominate more than the offline chain says it should.
+      if (lwetdep == 1) then
+        zlam(:,:) = scava*(max(prec(:,:),0.)*3.6E6)**scavb
+        do k=1,nl
+          mmr(:,:,k,ic) = mmr(:,:,k,ic)*exp(-min(zlam(:,:)*deltsec,50.))
+        enddo
+      endif
+
       where(mmr .lt. 0.) mmr = 0.0
       
       call mmr2n(mmr(:,:,:,ic),apart,rhop,rhog,im,jm,nl,numrhos(:,:,:,ic))

--- a/exoplasim/plasim/src/aeromod.f90
+++ b/exoplasim/plasim/src/aeromod.f90
@@ -44,6 +44,48 @@
       real :: rhop = 1000 ! Density of aerosol particle in kg/m3
       real :: fcoeff = 10e-13 ! Haze mass mixing ratio in kg/kg
 
+!     Removal. Both terms are OFF by default, so one executable can run both
+!     arms of an A/B and differ only by a namelist key. That is WORKFLOW.md
+!     A3 and it is not a style preference: the low-I/O patch changes the
+!     restart layout, so two arms built either side of a rebuild cannot share
+!     a restart at all, and a term that cannot be switched off cannot be
+!     tested.
+!
+!     ldepvel  0 = the legacy bottom-level sink, mmr = mmr*0.01 every step.
+!                  It is a stability hack rather than a parameterisation: the
+!                  implied deposition velocity is two orders of magnitude
+!                  above any measured one, and because it does not scale with
+!                  the timestep the implied velocity is inversely
+!                  proportional to it. A rate that depends on the integration
+!                  step is not a rate.
+!              1 = a deposition velocity. The bottom layer keeps
+!                  exp(-vdaero*dt/dz) per step, with dz built from the
+!                  layer's own pressure thickness and gas density, so the
+!                  rate is a property of the atmosphere and not of the step.
+!     vdaero   the NON-gravitational dry deposition velocity, m/s: turbulent
+!              transfer and impaction. Sedimentation to the surface is
+!              already carried by the settling flux leaving the bottom layer,
+!              so putting a settling term here as well would count it twice.
+!              There is no default: aero_ini refuses ldepvel = 1 with vdaero
+!              at or below zero rather than invent one, because the value
+!              belongs with the rest of the removal budget in
+!              the run's own configuration.
+!     lwetdep  0 = no wet removal, which is what ExoPlaSim has and what the
+!                  LMD Generic PCM has as well.
+!              1 = below-cloud scavenging at Lambda = scava * p**scavb, with
+!                  p the total precipitation rate in mm/h. That is the
+!                  Sportisse (2007) form an offline chain
+!                  already uses, so the two chains agree in form and not only
+!                  in magnitude.
+!     scava    that A, in s-1 per (mm/h)**B. No default, same reasoning as
+!              vdaero; the run's own configuration carries it and its bracket.
+!     scavb    that B, dimensionless. No default.
+      integer :: ldepvel = 0
+      integer :: lwetdep = 0
+      real :: vdaero = 0.0
+      real :: scava  = 0.0
+      real :: scavb  = 0.0
+
       end module aeromod
 
 !     ==================
@@ -54,7 +96,8 @@
       use aeromod
       use radmod, only: l_aerorad, aerofile
       
-      namelist/aero_nl/l_source,l_bulk,apart,rhop,fcoeff,l_aerorad,aerofile
+      namelist/aero_nl/l_source,l_bulk,apart,rhop,fcoeff,l_aerorad,aerofile  &
+     &                ,ldepvel,vdaero,lwetdep,scava,scavb
 
       if (mypid==NROOT) then
          open(11,file=aero_namelist)
@@ -66,6 +109,26 @@
          write(nud,'(" * Namelist AERO_NL from <aero_namelist> *")')
          write(nud,'(" *********************************************")')
          write(nud,aero_nl)
+!
+!        Refuse a switch that is on without the coefficient it needs, rather
+!        than carry a plausible-looking default that nothing in the run
+!        decided. Both values live in the run's own configuration.
+!
+         if (ldepvel == 1 .and. vdaero <= 0.0) then
+            write(nud,*) '* ldepvel = 1 needs a positive vdaero in m/s.'
+            write(nud,*) '* It is the non-gravitational dry deposition'
+            write(nud,*) '* velocity; settling is already carried by the'
+            write(nud,*) '* sedimentation flux. There is no defensible'
+            write(nud,*) '* default, so it must be set explicitly.'
+            call mpabort('aero_nl: ldepvel = 1 without vdaero')
+         endif
+         if (lwetdep == 1 .and. (scava <= 0.0 .or. scavb <= 0.0)) then
+            write(nud,*) '* lwetdep = 1 needs positive scava and scavb.'
+            write(nud,*) '* Lambda = scava * p**scavb with p in mm/h.'
+            write(nud,*) '* Both are aerosol- and rain-specific and have no'
+            write(nud,*) '* defensible default, so both must be set.'
+            call mpabort('aero_nl: lwetdep = 1 without scava and scavb')
+         endif
       endif
       
       return
@@ -79,8 +142,8 @@
       subroutine aero_main
 
       use pumamod, only: du,dv,dp,du0,dv0,dp0,daeros,numrhos, &
-                         NLON,NLAT,NLEV,NAERO,       &
-                         mypid,NROOT,sigmah,dt,dls,dswfl
+                         NLON,NLAT,NLEV,NAERO,NHOR,   &
+                         mypid,NROOT,sigmah,dt,dls,dswfl,dprl,dprc
       use tracermod
       use aeromod
       use radmod, only: gmu0, l_aerorad ! Use cosine of solar zenith angle from radmod;
@@ -105,6 +168,9 @@
 !     is used against them. Upstream did not, so the land mask and the solar
 !     zenith angle drove the aerosol source in the wrong hemisphere.
       real ::   zgath(NLON,NLAT,NLEV)
+
+      real ::   prec(NLON,NLAT) ! Total precipitation rate (m/s), for lwetdep
+      real ::   zprec(NHOR)     ! the same before gathering
 
       integer :: j,jc
 
@@ -146,6 +212,20 @@
        end select
       end if 
 
+!     Precipitation for the wet-scavenging term, large scale plus convective,
+!     in m/s. Gathered only when the term is on, so that lwetdep = 0 costs
+!     nothing and reproduces the unpatched model exactly. Flipped in latitude
+!     like every other field gathered here.
+
+      prec(:,:) = 0.0
+      if (lwetdep == 1) then
+         zprec(:) = dprl(:) + dprc(:)
+         call mpgagp(zgath,zprec,1)
+         do j=1,NLAT
+            prec(:,NLAT+1-j) = zgath(:,j,1)
+         end do
+      end if
+
       if (mypid == NROOT .and. aero_debug) then
          write(nud,'(a,f11.2)') '* max aero u   =',maxval(abs(zu))
          write(nud,'(a,f11.2)') '* max v   =',maxval(abs(zv))
@@ -173,7 +253,7 @@
                       colae,colad,rcolad,dlat,rcap,       &
                       aero_cnst,aero_deform,aero_zcross,  &
                       aero_fill,aero_mfct,aero_debug,nud, &
-                      angle,land,aerosw,l_aerorad)
+                      angle,land,aerosw,l_aerorad,prec)
 
 !        preparation for the GUI output: 
 !        invert the meridional direction and add the 360 deg. longitude

--- a/exoplasim/plasim/src/aeromod.f90
+++ b/exoplasim/plasim/src/aeromod.f90
@@ -98,6 +98,14 @@
       real ::   aerosw(NLON,NLAT,NLEV) ! Array for SW flux 
       real ::   land(NLON,NLAT) ! Array for binary land mask
 
+!     Gather buffer. mpgagp returns a field in the MODEL's latitude order,
+!     while daeros and numrhos are handed to aerocore flipped south-to-north
+!     (see plasim.f90, `daeros(:,NLAT+1-jlat,:,1) = zmmr(:,jlat,:)`). Every
+!     field gathered here therefore has to be flipped the same way before it
+!     is used against them. Upstream did not, so the land mask and the solar
+!     zenith angle drove the aerosol source in the wrong hemisphere.
+      real ::   zgath(NLON,NLAT,NLEV)
+
       integer :: j,jc
 
       character(len=9) :: aero_name
@@ -111,18 +119,30 @@
        select case (l_source) ! Choose your aerosol source
        case(1) ! Case 1: photochemical haze
          call solang ! Use subroutine from radmod to calculate solar zenith angle
-         call mpgagp(angle,gmu0,1) ! Gather from nodes
+         call mpgagp(zgath,gmu0,1) ! Gather from nodes
+         do j=1,NLAT
+            angle(:,NLAT+1-j) = zgath(:,j,1)
+         end do
        case(2) ! Case 2: dust
-         call mpgagp(land,dls,1) ! Import land-sea mask from landmod and reshape to match grid size
+         call mpgagp(zgath,dls,1) ! Import land-sea mask from landmod and reshape to match grid size
+         do j=1,NLAT
+            land(:,NLAT+1-j) = zgath(:,j,1)
+         end do
        end select
       end if
       
       if (l_aerorad == 1) then ! Include radiative transfer
        select case (l_source) ! Choose aerosol source
        case(1) ! Case 1: photochemical haze     
-        call mpgagp(aerosw,dswfl,NLEV) ! Gather SW flux from nodes
+        call mpgagp(zgath,dswfl,NLEV) ! Gather SW flux from nodes
+        do j=1,NLAT
+           aerosw(:,NLAT+1-j,:) = zgath(:,j,:)
+        end do
        case(2) ! Case 2: dust
-        call mpgagp(land,dls,1) ! Import land-sea mask from landmod and reshape to match grid size
+        call mpgagp(zgath,dls,1) ! Import land-sea mask from landmod and reshape to match grid size
+        do j=1,NLAT
+           land(:,NLAT+1-j) = zgath(:,j,1)
+        end do
        end select
       end if 
 


### PR DESCRIPTION
**Stacked on #58, and please read the interaction below before merging #58 on its own.** GitHub will show #58's commit as the base here; the second commit is this change.

### The sink that is not a rate

The aerosol has one physical removal path, sedimentation, plus a line at the bottom of the tracer loop:

```fortran
mmr(:,:,nl,ic) = mmr(:,:,nl,ic)*10e-3
```

Because it is per **step** rather than per unit time, the implied removal timescale is `dt/ln(100)` — halve the timestep and you halve the timescale and double the implied deposition velocity, so the removal rate is set by the integration rather than by the physics. For a rocky-planet configuration at a 15-minute timestep it works out around 195 s over one bottom layer, orders of magnitude faster than measured dry deposition velocities for sub-micron particles.

### What the cited settling papers supply

The settling here is usually described in terms of Parmentier et al. (2013) and Steinrueck et al. (2021). Both supply the settling **velocity** — Parmentier's Appendix A equates gravity and drag with tabulated drag coefficients between the Stokes limit and CD = 0.45 — and neither carries a surface-deposition treatment, since both model gas giants with no surface. Steinrueck's lower boundary condition is a deep sink, `L = -χ/τ_loss` for `p > p_deep` with **τ_loss = 10³ s** and **p_deep = 100 mbar**, standing in for cloud nucleation and thermal ablation on a hot Jupiter: a rate with an explicit timescale, fixed independently of the timestep, acting over a deep region.

The line above is none of that. It is per-step, it acts in a single layer, and for a rocky planet the bottom layer is a **surface**, where the usual treatment is a deposition velocity. So it is this module's own, rather than something inherited from either citation, and replacing it does not contradict a published design.

### Why this matters for #58 specifically

#58 fixes the sign of the bottom-layer settling term — stock **adds** `gz(nl)` where it must subtract it, so nothing ever leaves the atmosphere by sedimentation and the bottom layer builds up without bound. The 99%-per-step line is what holds it down.

| state | what removes aerosol at the surface |
|---|---|
| stock | the 99%/step scrub only; sedimentation is sign-inverted and removes nothing |
| **#58 alone** | sedimentation **and** the scrub — more removal than before |
| #58 + this | sedimentation, with the scrub replaceable by a timestep-independent velocity |

So #58 on its own does not simply restore the intended scheme: it leaves the per-step scrub in place alongside a sedimentation term that now works. Whether the `ldepvel = 0` default should keep that line at all once the sign is fixed is your call — keeping it preserves existing results bit for bit, dropping it makes the model match how the scheme is usually described.

### The change

`vdaero` is applied as a flux over the bottom layer's own geometric depth and the timestep, so the same physical velocity gives the same removal whatever the step. It is the **non-gravitational** part on purpose: settling out of the bottom layer is already the `gz(nl)` term, and adding a Stokes velocity here would deposit the same mass twice.

There is also **no wet deposition of any kind**, which for a soluble or wettable aerosol in a model with a full hydrological cycle is the dominant sink on Earth. Below-cloud scavenging is added as `Λ = scava · p^scavb` with p in mm/h.

Both switches default off (`ldepvel = 0`, `lwetdep = 0`), and enabling either without its coefficients aborts rather than choosing a number — the right values depend on particle size, density, surface type and rain, and differ between an ocean surface and a vegetated or desert one. Compiles at T21/8.
