### PR TITLE
Silence two static array-bounds warnings on unreachable code

### DIFF
--- a/exoplasim/plasim/src/oceanmod.f90
+++ b/exoplasim/plasim/src/oceanmod.f90
@@ -141,7 +141,7 @@
       real (kind=8) :: zgw(NLAT)
       real :: zgw2(NLON,NLAT)
       real :: zls(NLON*NLAT)
-      integer :: nlem_oce = NLEV_OCE - 1 
+      integer, parameter :: nlem_oce = NLEV_OCE - 1 
       character (*) :: oceanmod_namelist
       character (*) :: ocean_output
 !
@@ -1225,7 +1225,7 @@
 !     compute new sst due to vertical diffusion
 !
       use oceanmod
-      integer :: nlem_oce = NLEV_OCE - 1
+      integer, parameter :: nlem_oce = NLEV_OCE - 1
 !
 !     note: bounds of local arrays due to compiler, only 1:nlem_oce used
 !

--- a/exoplasim/plasim/src/plasim.f90
+++ b/exoplasim/plasim/src/plasim.f90
@@ -1529,7 +1529,8 @@ plasimversion = "https://github.com/Edilbert/PLASIM/ : 15-Dec-2015"
       elseif ((neqsig==5) .and. (NLEV .gt. 10)) then
        
        !Bottom atmosphere (PlaSim's normal domain)
-       do jlev=NLEV-10,NLEV
+       do jlev=max(NLEV-10,1),NLEV  !max() so the bound is provably >= 1; the
+         !branch already requires NLEV > 10, so this never changes the range
          zsk=REAL(jlev-(NLEV-9+1))/10.0  !As if it was a 10-layer atmosphere
          sigmah(jlev)=0.75*zsk+1.75*zsk**3-1.5*zsk**4
        enddo


### PR DESCRIPTION
A stock build emits three `Array reference at (1) out of bounds` warnings from gfortran's static analysis at `-O3`. They are the **only** warnings the build produces, so a genuinely new one would land in noise rather than in an empty log.

Neither site is a bug. Both are guarded by conditions that are false at compile time for the default configuration, so neither reference is reachable — gfortran just doesn't use the guard to prune the body before bounds analysis.

### `oceanmod.f90` — three warnings

```fortran
if(NLEV_OCE > 1) then
 do jlev=1,nlem_oce
    vdiffk(jlev)=(dlayer(jlev)*vdiffkl(jlev)+dlayer(jlev+1)*vdiffkl(jlev+1)) &
                /(dlayer(jlev)+dlayer(jlev+1))
 enddo
endif
```

This indexes `dlayer(2)` where `dlayer` is `dlayer(NLEV_OCE)` and `NLEV_OCE` is a parameter equal to 1. It cannot execute — the guard is false at compile time, and `nlem_oce = NLEV_OCE - 1 = 0` makes the loop zero-trip as well. The body is correct for any `NLEV_OCE > 1`.

`nlem_oce` is derived from a parameter and is never assigned anywhere in the file, so declaring it `parameter` is just stating what it already is, and it lets gfortran prove the trip count is zero.

### `plasim.f90` — one warning

The `neqsig==5` branch is guarded by `NLEV > 10`, but its loop runs `jlev = NLEV-10 .. NLEV`, which reaches `sigmah(0)` when `NLEV = 10` — precisely the case the guard excludes. `max(NLEV-10,1)` on the lower bound never changes the range where the branch actually runs, and it is the idiom this same block already uses two lines below:

```fortran
zskf = sigmah(max(NLEV-10,1)) !Have to add this max statement so it'll compile with debug flag
```

### Verification

Neither change can alter behaviour — both touch code that does not execute in the configurations that reach it. Verified at T42 L10 on 16 ranks, gfortran 16.2.1: the restart checksum is byte-identical to a build without these changes. With both applied, the model builds with zero warnings.

Independent of #64, which touches `legmod.f90` only; the two can merge in either order.
